### PR TITLE
NEST-455: Making ApplicationInsightsTrackingInOfflineOperationShouldWorkAsync configurable

### DIFF
--- a/Lombiq.Hosting.Azure.ApplicationInsights.Tests.UI/TestCases/ApplicationInsightsTestCases.cs
+++ b/Lombiq.Hosting.Azure.ApplicationInsights.Tests.UI/TestCases/ApplicationInsightsTestCases.cs
@@ -3,6 +3,7 @@ using Lombiq.Tests.UI;
 using Lombiq.Tests.UI.Extensions;
 using Lombiq.Tests.UI.Services;
 using Shouldly;
+using System;
 using System.Threading.Tasks;
 
 namespace Lombiq.Hosting.Azure.ApplicationInsights.Tests.UI.TestCases;
@@ -10,7 +11,9 @@ namespace Lombiq.Hosting.Azure.ApplicationInsights.Tests.UI.TestCases;
 public static class ApplicationInsightsTestCases
 {
     public static Task ApplicationInsightsTrackingInOfflineOperationShouldWorkAsync(
-        ExecuteTestAfterSetupAsync executeTestAfterSetupAsync, Browser browser) =>
+        ExecuteTestAfterSetupAsync executeTestAfterSetupAsync,
+        Browser browser,
+        Func<OrchardCoreUITestExecutorConfiguration, Task> changeConfigurationAsync = null) =>
         executeTestAfterSetupAsync(
             async context =>
             {
@@ -25,8 +28,10 @@ public static class ApplicationInsightsTestCases
                 appInsightsExist.ShouldBe(expected: true, "The Application Insights module is not working or is not in offline mode.");
             },
             browser,
-            configuration =>
+            async configuration =>
             {
+                if (changeConfigurationAsync != null) await changeConfigurationAsync(configuration);
+
                 configuration.OrchardCoreConfiguration.BeforeAppStart +=
                     (_, argumentsBuilder) =>
                     {
@@ -37,7 +42,5 @@ public static class ApplicationInsightsTestCases
 
                         return Task.CompletedTask;
                     };
-
-                return Task.CompletedTask;
             });
 }


### PR DESCRIPTION
[NEST-455](https://lombiq.atlassian.net/browse/NEST-455)

[NEST-455]: https://lombiq.atlassian.net/browse/NEST-455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ