### PR TITLE
NEST-640: Adding js.monitor.azure.com as a connect-src CSP policy

### DIFF
--- a/Lombiq.Hosting.Azure.ApplicationInsights/Services/ApplicationInsightsContentSecurityPolicyProvider.cs
+++ b/Lombiq.Hosting.Azure.ApplicationInsights/Services/ApplicationInsightsContentSecurityPolicyProvider.cs
@@ -12,7 +12,7 @@ internal sealed class ApplicationInsightsContentSecurityPolicyProvider : IConten
     public ValueTask UpdateAsync(IDictionary<string, string> securityPolicies, HttpContext context)
     {
         CspHelper.MergeValues(securityPolicies, ScriptSrc, "js.monitor.azure.com");
-        CspHelper.MergeValues(securityPolicies, ConnectSrc, "*.applicationinsights.azure.com");
+        CspHelper.MergeValues(securityPolicies, ConnectSrc, "*.applicationinsights.azure.com", "js.monitor.azure.com");
 
         return ValueTask.CompletedTask;
     }


### PR DESCRIPTION
[NEST-640](https://lombiq.atlassian.net/browse/NEST-640)

[NEST-640]: https://lombiq.atlassian.net/browse/NEST-640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ