### PR TITLE
OSOE-1254: Fix MA0127 analyzer warning in AzureBlobTelemetryFilter

### DIFF
--- a/Lombiq.Hosting.Azure.ApplicationInsights/Services/AzureBlobTelemetryFilter.cs
+++ b/Lombiq.Hosting.Azure.ApplicationInsights/Services/AzureBlobTelemetryFilter.cs
@@ -40,7 +40,9 @@ public class AzureBlobTelemetryFilter : ITelemetryProcessor
             return;
         }
 
-        if (_parentId == dependency.Id && dependency.Name is "Blob.GetProperties" or "BlobBaseClient.GetProperties")
+        if (_parentId == dependency.Id &&
+            (dependency.Name.EqualsOrdinalIgnoreCase("Blob.GetProperties") ||
+            dependency.Name.EqualsOrdinalIgnoreCase("BlobBaseClient.GetProperties")))
         {
             _parentId = dependency.Context.Operation.ParentId;
             dependency.SetAsIgnoredFailure();


### PR DESCRIPTION
[OSOE-1254](https://lombiq.atlassian.net/browse/OSOE-1254): Fix MA0127 analyzer warning.

- Use EqualsOrdinalIgnoreCase instead of is pattern in AzureBlobTelemetryFilter

[OSOE-1254]: https://lombiq.atlassian.net/browse/OSOE-1254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ